### PR TITLE
add vertical scrolling to sidebar

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -27,7 +27,8 @@ body {
 }
 
 .site-links {
-
+    max-height: 100%;
+    overflow: scroll;
 }
 
 .site-links .link {


### PR DESCRIPTION
I had trouble accessing links at the bottom before.

Before:
![Screenshot from 2020-09-25 15-35-23](https://user-images.githubusercontent.com/1899701/94321650-177b3c00-ff45-11ea-958e-5c5d5b1a5f26.png)

After:
![Screenshot from 2020-09-25 15-36-13](https://user-images.githubusercontent.com/1899701/94321651-19dd9600-ff45-11ea-99e8-b0788b7fc3ac.png)


